### PR TITLE
Routes are namespaced by now

### DIFF
--- a/http.go
+++ b/http.go
@@ -122,10 +122,10 @@ func GetPostHandler(ctx *fasthttp.RequestCtx) {
 
 func StartHTTP() {
 	router := fasthttprouter.New()
-	router.GET("/search_posts", SearchPostsHandler)
-	router.GET("/search_comments", SearchCommentsHandler)
-	router.GET("/posts/:id", GetPostHandler)
-	router.GET("/posts", GetPostsHandler)
+	router.GET("/api/search_posts", SearchPostsHandler)
+	router.GET("/api/search_comments", SearchCommentsHandler)
+	router.GET("/api/posts/:id", GetPostHandler)
+	router.GET("/api/posts", GetPostsHandler)
 	log.Printf("Starting listen fasthttp on 8881")
 	if err := fasthttp.ListenAndServe(":8881", router.Handler); err != nil {
 		panic(err)


### PR DESCRIPTION
I want to use your API in my frontend application. There is a necessity to put the routes into a single namespace. That allows us to follow best practice in my application building and API integration . Please, accept this PR as soon as possible.